### PR TITLE
feat: add extension for parsing message

### DIFF
--- a/pytoncenter/debug.py
+++ b/pytoncenter/debug.py
@@ -7,9 +7,9 @@ from .utils import get_opcode
 
 __all__ = [
     "NamedFunction",
-    "truncateMiddlePart",
+    "truncate_middle",
     "create_named_mapping_func",
-    "defaultNamedFunction",
+    "default_named_func",
     "format_trace_tx",
     "pretty_print_trace_tx",
 ]
@@ -17,15 +17,15 @@ __all__ = [
 NamedFunction = Callable[[str], Optional[str]]
 
 
-def truncateMiddlePart(address: Address, prefix: int, suffix: int) -> str:
+def truncate_middle(address: Address, prefix: int = 6, suffix: int = 6) -> str:
     """
     Truncate middle part of the address to make it more readable
     """
-    address = address.to_string(True, is_test_only=False)
-    return address[:prefix] + "..." + address[-suffix:] if len(address) > prefix + suffix else address
+    addr = address.to_string(True, is_test_only=False)
+    return addr[:prefix] + "..." + addr[-suffix:] if len(addr) > prefix + suffix else addr
 
 
-def defaultNamedFunction(address: Address, **kwargs) -> Optional[str]:
+def default_named_func(address: Address, **kwargs) -> Optional[str]:
     """
     Truncate middle part of the address to make it more readable
 
@@ -40,10 +40,10 @@ def defaultNamedFunction(address: Address, **kwargs) -> Optional[str]:
     """
     prefix = kwargs.get("prefix", 6)
     suffix = kwargs.get("suffix", 6)
-    return truncateMiddlePart(address, prefix, suffix)
+    return truncate_middle(address, prefix, suffix)
 
 
-def format_trace_tx(trace_tx: TraceTx, named_func: NamedFunction = defaultNamedFunction) -> str:
+def format_trace_tx(trace_tx: TraceTx, named_func: NamedFunction = default_named_func) -> str:
     """
     Format transaction trace in a pretty way
     A -> B (Value, Opcode)
@@ -78,13 +78,13 @@ def create_named_mapping_func(mapping: Dict[Address, str], truncate_address: boo
         """
         Truncate middle part of the address to make it more readable
         """
-        default = truncateMiddlePart(address, 6, 6) if truncate_address else address.to_string(True, is_test_only=False)
+        default = truncate_middle(address, 6, 6) if truncate_address else address.to_string(True, is_test_only=False)
         return mapping.get(address, default)
 
     return namedFunction
 
 
-def pretty_print_trace_tx(trace_tx: TraceTx, named_func: NamedFunction = defaultNamedFunction):
+def pretty_print_trace_tx(trace_tx: TraceTx, named_func: NamedFunction = default_named_func):
     """
     print transaction trace in a pretty way
     """

--- a/pytoncenter/extension/message.py
+++ b/pytoncenter/extension/message.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+from tonpy import CellSlice, Cell
+from abc import ABC, abstractmethod
+from pytoncenter.address import Address
+from pytoncenter.utils import get_opcode
+from typing import Optional, TypeVar, Generic
+
+T = TypeVar("T", bound="BaseMessage")
+
+
+class BaseMessage(ABC, Generic[T]):
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    @property
+    def OPCODE(self) -> Optional[str]:
+        return None
+
+    @classmethod
+    def _preparse(cls, cs: CellSlice) -> CellSlice:
+        opcode = get_opcode(cs.load_uint(32))
+        assert opcode == cls.OPCODE, f"opcode {opcode} is not {cls.OPCODE}"
+        return cs
+
+    @classmethod
+    @abstractmethod
+    def _parse(cls, body: CellSlice) -> T:
+        """
+        the cellslice with opcode and body
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def parse(cls, cs: CellSlice) -> T:
+        body = cls._preparse(cs)
+        return cls._parse(body)
+
+    def to_boc(self) -> str:
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"{self.name}({self.OPCODE})"
+
+
+class JettonInternalTransfer(BaseMessage["JettonInternalTransfer"]):
+    OPCODE = "0x178d4519"
+
+    def __init__(
+        self,
+        query_id: int,
+        amount: int,
+        sender: Address,
+        response_address: Address,
+        forward_ton_amount: int,
+        forward_payload: Optional[CellSlice],
+    ):
+        self.query_id = query_id
+        self.amount = amount
+        self.sender = sender
+        self.response_address = response_address
+        self.forward_ton_amount = forward_ton_amount
+        self.forward_payload = forward_payload
+
+    @classmethod
+    def _parse(cls, body: CellSlice):
+        """
+        internal_transfer  query_id:uint64 amount:(VarUInteger 16) from:MsgAddress
+                     response_address:MsgAddress
+                     forward_ton_amount:(VarUInteger 16)
+                     forward_payload:(Either Cell ^Cell)
+        """
+        query_id = body.load_uint(64)
+        amount = body.load_var_int(16)
+        sender = Address(body.load_address())
+        response_address = Address(body.load_address())
+        forward_ton_amount = body.load_var_uint(16)
+        forward_payload = None if body.empty_ext() else body.load_ref(as_cs=True)
+        return cls(
+            query_id=query_id,
+            amount=amount,
+            sender=sender,
+            response_address=response_address,
+            forward_ton_amount=forward_ton_amount,
+            forward_payload=forward_payload,
+        )
+
+
+class JettonTransfer(BaseMessage["JettonTransfer"]):
+    OPCODE = "0x0f8a7ea5"
+
+    def __init__(
+        self,
+        query_id: int,
+        amount: int,
+        destination: Address,
+        response_destination: Address,
+        custom_payload: Optional[CellSlice],
+        forward_ton_amount: int,
+        forward_payload: Optional[CellSlice],
+    ):
+        self.query_id = query_id
+        self.amount = amount
+        self.destination = destination
+        self.response_destination = response_destination
+        self.custom_payload = custom_payload
+        self.forward_ton_amount = forward_ton_amount
+        self.forward_payload = forward_payload
+
+    @classmethod
+    def _parse(cls, body: CellSlice):
+        """
+        transfer query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress
+           response_destination:MsgAddress custom_payload:(Maybe ^Cell)
+           forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell)
+        """
+        query_id = body.load_uint(64)
+        amount = body.load_var_uint(16)
+        destination = Address(body.load_address())
+        response_destination = Address(body.load_address())
+
+        custom_payload = None
+        custom_payload_exists = body.load_bool()
+        if custom_payload_exists:
+            custom_payload = body.load_ref(as_cs=True)
+
+        forward_ton_amount = body.load_var_uint(16)
+
+        forward_payload = None
+        if not body.empty_ext():
+            forward_payload = body.load_ref(as_cs=True)
+
+        return cls(query_id, amount, destination, response_destination, custom_payload, forward_ton_amount, forward_payload)
+
+
+class Excess(BaseMessage["Excess"]):
+    OPCODE = "0xd53276db"
+
+    def __init__(self, query_id: int):
+        self.query_id = query_id
+
+    @staticmethod
+    def _parse(cs: CellSlice) -> Excess:
+        """
+        excess query_id:uint64 amount:(VarUInteger 16)
+        """
+        query_id = cs.load_uint(64)
+        return Excess(query_id)
+
+
+class TransferNotification(BaseMessage["TransferNotification"]):
+    OPCODE = "0x7362d09c"
+
+    def __init__(self, query_id: int, amount: int, sender: Address, forward_payload: Optional[CellSlice]):
+        self.query_id = query_id
+        self.amount = amount
+        self.sender = sender
+        self.forward_payload = forward_payload
+
+    @classmethod
+    def _parse(cls, body: CellSlice) -> TransferNotification:
+        """
+        transfer_notification query_id:uint64 amount:(VarUInteger 16)
+           sender:MsgAddress forward_payload:(Either Cell ^Cell)
+        """
+        query_id = body.load_uint(64)
+        amount = body.load_var_uint(16)
+        sender = Address(body.load_address())
+        forward_payload = None
+        if not body.empty_ext():
+            forward_payload = body.load_ref(as_cs=True)
+        return cls(query_id, amount, sender, forward_payload)
+
+
+class JettonBurn(BaseMessage["JettonBurn"]):
+    OPCODE = "0x595f07bc"
+
+    def __init__(
+        self,
+        query_id: int,
+        amount: int,
+        response_destination: Address,
+        custom_payload: Optional[CellSlice],
+    ):
+        self.query_id = query_id
+        self.amount = amount
+        self.response_destination = response_destination
+        self.custom_payload = custom_payload
+
+    @classmethod
+    def _parse(cls, body: CellSlice) -> JettonBurn:
+        """
+        burn query_id:uint64 amount:(VarUInteger 16)
+            response_destination:MsgAddress custom_payload:(Maybe ^Cell)
+        """
+        query_id = body.load_uint(64)
+        amount = body.load_var_uint(16)
+        response_destination = Address(body.load_address())
+        custom_payload = None
+        custom_payload_exists = body.load_bool()
+        if custom_payload_exists:
+            custom_payload = body.load_ref(as_cs=True)
+        return cls(query_id, amount, response_destination, custom_payload)
+
+
+class JettonBurnNotification(BaseMessage["JettonBurnNotification"]):
+    OPCODE = "0x7bdd97de"
+
+    def __init__(self, query_id: int, amount: int, sender: Address, response_destination: Address):
+        self.query_id = query_id
+        self.amount = amount
+        self.sender = sender
+        self.response_destination = response_destination
+
+    @classmethod
+    def _parse(cls, body: CellSlice) -> JettonBurnNotification:
+        """
+        burn_notification query_id:uint64 amount:(VarUInteger 16)
+            sender:MsgAddress response_destination:MsgAddress
+        """
+        query_id = body.load_uint(64)
+        amount = body.load_var_uint(16)
+        sender = Address(body.load_address())
+        response_destination = Address(body.load_address())
+        return cls(query_id, amount, sender, response_destination)

--- a/pytoncenter/utils.py
+++ b/pytoncenter/utils.py
@@ -7,6 +7,7 @@ import base64
 
 __all__ = [
     "get_opcode",
+    "encode_base64",
     "decode_base64",
 ]
 
@@ -16,6 +17,15 @@ def get_opcode(data_uint32: int) -> str:
     Get opcode from uint32, the output is a string with 0x prefix, 10 characters long.
     """
     return "0x{:08x}".format(data_uint32).lower()
+
+
+def encode_base64(hex_data: str) -> str:
+    # Convert the hex data back into bytes
+    bytes_data = bytes.fromhex(hex_data)
+    # Encode these bytes into a base64 string
+    base64_encoded = base64.b64encode(bytes_data)
+    # Return the base64-encoded string
+    return base64_encoded.decode()
 
 
 def decode_base64(data: str) -> str:

--- a/tests/extension.py
+++ b/tests/extension.py
@@ -1,0 +1,48 @@
+import pytest
+from pytoncenter.address import Address
+from pytoncenter.extension.message import JettonInternalTransfer, JettonTransfer, Excess
+from tonpy import CellSlice
+from pytoncenter.utils import encode_base64
+
+
+class TestJettonParse:
+    def test_jetton_internal_transfer_parse(self):
+
+        # https://testnet.tonviewer.com/transaction/b9638bbcc640b0cdd559c1be8344c73da14e3c91f7f59f250b9a8a38e063d8ba
+        raw_body = encode_base64(
+            "b5ee9c720101020100a10001ad178d4519000000000000000034c4b3f80052ea860872970f38347c8a4eb7149232cef52c45ac96eaf1e4fbfeca6fef25cb000a5d50c10e52e1e7068f9149d6e2924659dea588b592dd5e3c9f7fd94dfde4b952e7ddb00201008a010000000000000000000000000000000000000000000000000000000000000016000000010000000000000000000000000000000000000000000000000147ae147ae147ae"
+        )
+        cs = CellSlice(raw_body)
+        msg = JettonInternalTransfer.parse(cs)
+        assert msg.query_id == 0
+        assert msg.amount == 4999999
+        assert msg.sender == Address("0:29754304394b879c1a3e45275b8a4919677a9622d64b7578f27dff6537f792e5")
+        assert msg.response_address == Address("0:29754304394b879c1a3e45275b8a4919677a9622d64b7578f27dff6537f792e5")
+        assert msg.forward_ton_amount == 3120000000
+        assert msg.forward_payload is not None
+        oralce_opcode = msg.forward_payload.load_uint(8)
+        expire_at = msg.forward_payload.load_uint(256)
+        assert oralce_opcode == 1  # Tick Message
+        assert expire_at != 0
+
+    def test_jetton_excess(self):
+        # https://testnet.tonviewer.com/transaction/ee014cc0d95cd5589951956b11095de7dcb6288a126397a55f789a962f3d815f
+        raw_body = encode_base64("b5ee9c7201010101000e000018d53276db0000000000000000")
+        cs = CellSlice(raw_body)
+        msg = Excess.parse(cs)
+        assert msg.query_id == 0
+
+    def test_jetton_transfer(self):
+        # https://testnet.tonviewer.com/transaction/64b0320c972ca8b0815798705dca60b8c28afdc8e5d8aa08e790d851b4dda22f
+        raw_body = encode_base64(
+            "b5ee9c720101020100a10001ad0f8a7ea5000000000000000034c4b3f8017bc28408f06d3fc030d138584d9fcb47783984a2c899f8ac8a2fda3678a085fd000a5d50c10e52e1e7068f9149d6e2924659dea588b592dd5e3c9f7fd94dfde4b94973eed80101008a010000000000000000000000000000000000000000000000000000000000000016000000010000000000000000000000000000000000000000000000000147ae147ae147ae"
+        )
+        cs = CellSlice(raw_body)
+        msg = JettonTransfer.parse(cs)
+        assert msg.query_id == 0
+        assert msg.amount == 4999999
+        assert msg.destination == Address("kQC94UIEeDaf4BhonCwmz-WjvBzCUWRM_FZFF-0bPFBC_pDZ")
+        assert msg.response_destination == Address("0QApdUMEOUuHnBo-RSdbikkZZ3qWItZLdXjyff9lN_eS5Zib")
+        assert msg.custom_payload == None
+        assert msg.forward_ton_amount == 3120000000
+        assert msg.forward_payload is not None


### PR DESCRIPTION
* feat(examples/subscribe.py): add support for handling JettonInternalTransfer and JettonTransfer messages
* fix(pytoncenter/debug.py): change truncateMiddlePart function name to truncate_middle
* fix(pytoncenter/debug.py): change defaultNamedFunction function name to default_named_func
* fix(pytoncenter/debug.py): change format_trace_tx function name to format_trace_tx
* fix(pytoncenter/debug.py): change pretty_print_trace_tx function name to pretty_print_trace_tx
* feat(pytoncenter/extension/message.py): add JettonInternalTransfer message class
* feat(pytoncenter/extension/message.py): add JettonTransfer message class
* fix(pytoncenter/utils.py): add encode_base64 function
* fix(pytoncenter/utils.py): add decode_base64 function
* test(extension.py): add tests for parsing JettonInternalTransfer, Excess, and JettonTransfer messages