### PR TITLE
Remove unused import statement in message.py

### DIFF
--- a/pytoncenter/extension/message.py
+++ b/pytoncenter/extension/message.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from tonpy import CellSlice, Cell
+from tonpy import CellSlice
 from abc import ABC, abstractmethod
 from pytoncenter.address import Address
 from pytoncenter.utils import get_opcode


### PR DESCRIPTION
This pull request removes an unused import statement in the message.py file. This import statement is no longer needed and can be safely removed.