### PR TITLE
Update CI workflow to run only on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,15 +4,13 @@ on:
   pull_request:
     branches:
       - "*"
-  push:
-    branches:
-      - "main"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     timeout-minutes: 10
     permissions:
       pull-requests: write


### PR DESCRIPTION
This pull request updates the CI workflow to run only on pull requests, ensuring that the workflow is triggered only when necessary.